### PR TITLE
Basic unit testing

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[run]
+branch = 1
+cover_pylib = 0
+source = shipwire
+omit = */tests/*, */test_*.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: python
+sudo: false
+cache:
+  directories:
+    - $HOME/.cache/pip
+python:
+  - "2.7"
+  - "3.2"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.5-dev"
+  - "nightly"
+matrix:
+  allow_failures:
+    - python: "3.5-dev"
+    - python: "nightly"
+install:
+  - travis_retry pip install .
+  # Coveralls 4.0 doesn't support Python 3.2
+  - if [ "$TRAVIS_PYTHON_VERSION" == "3.2" ]; then travis_retry pip install coverage==3.7.1; fi
+  - if [ "$TRAVIS_PYTHON_VERSION" != "3.2" ]; then travis_retry pip install coverage; fi
+  - travis_retry pip install mock coveralls
+script: coverage run -m unittest discover
+after_success: coveralls

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 shipwire-python
 ===============
 
+[![Build Status](https://travis-ci.org/soylentme/shipwire-python.svg?branch=master)](https://travis-ci.org/soylentme/shipwire-python)
+[![Coverage Status](https://coveralls.io/repos/soylentme/shipwire-python/badge.svg?branch=master&service=github)](https://coveralls.io/github/soylentme/shipwire-python?branch=master)
+
 A Python abstraction layer around the Shipwire API.
 
 #####Installing:

--- a/shipwire/tests/test_api.py
+++ b/shipwire/tests/test_api.py
@@ -1,0 +1,254 @@
+from unittest import TestCase
+
+from shipwire import api, responses
+
+try:
+    from unittest.mock import MagicMock, patch
+except ImportError:
+    from mock import MagicMock, patch
+
+
+@patch('shipwire.requests.request', new=MagicMock())
+class ShipwireTestCase(TestCase):
+    def setUp(self):
+        self.client = api.Shipwire()
+
+    def assert_url(self, client, url):
+        base = '{}://{}/api/v{}'.format(
+            'https' if client.secure else 'http',
+            client.host, client.api_version)
+
+        actual = api.requests.request.call_args[0][1]
+        self.assertEqual(base + url, actual)
+
+    def assert_method(self, method):
+        actual = api.requests.request.call_args[0][0]
+        self.assertEqual(method.upper(), actual.upper())
+
+    def assert_url_method(self, client, method, url):
+        self.assert_method(method)
+        self.assert_url(client, url)
+
+    def test_get_resource(self):
+        for resource in api.METHODS:
+            resource_client = getattr(self.client, resource)
+            self.assertEqual(resource, resource_client.resource)
+
+    def test_get_resource_immutable(self):
+        for resource in api.METHODS:
+            self.assertIsNot(self.client, getattr(self.client, resource))
+            self.assertNotEqual(resource, self.client.resource)
+
+    def test_get_invalid_resource(self):
+        with self.assertRaises(api.ShipwireError):
+            self.client.not_a_real_resource
+
+    def test_get_invalid_method(self):
+        for resource in api.METHODS:
+            with self.assertRaises(api.ShipwireError):
+                getattr(self.client, resource).not_a_real_method
+
+    def test_call_on_uninitialized_client(self):
+        with self.assertRaises(api.ShipwireError):
+            self.client()
+
+    def test_call_on_client_without_method(self):
+        with self.assertRaises(api.ShipwireError):
+            self.client.orders()
+
+    def test_call_generates_correct_order_url(self):
+        self.client.orders.list()
+        self.assert_url_method(self.client, 'GET', '/orders')
+
+        # For backwards-compatibility reasons, list can be called on either
+        # ``orders`` or ``order``.
+        self.client.order.list()
+        self.assert_url_method(self.client, 'GET', '/orders')
+
+        self.client.order.create()
+        self.assert_url_method(self.client, 'POST', '/orders')
+
+        self.client.order.get(id=12345)
+        self.assert_url_method(self.client, 'GET', '/orders/12345')
+
+        self.client.order.modify(id=54321)
+        self.assert_url_method(self.client, 'PUT', '/orders/54321')
+
+        self.client.order.items(id=12345)
+        self.assert_url_method(self.client, 'GET', '/orders/12345/items')
+
+        self.client.order.holds(id=12345)
+        self.assert_url_method(self.client, 'GET', '/orders/12345/holds')
+
+        self.client.order.returns(id=12345)
+        self.assert_url_method(self.client, 'GET', '/orders/12345/returns')
+
+        self.client.order.trackings(id=12345)
+        self.assert_url_method(self.client, 'GET', '/orders/12345/trackings')
+
+    def test_call_generates_correct_stock_urls(self):
+        self.client.stock.products()
+        self.assert_url_method(self.client, 'GET', '/stock')
+
+    def test_call_generates_correct_rate_urls(self):
+        self.client.rate.quote()
+        self.assert_url_method(self.client, 'POST', '/rate')
+
+    def test_call_generates_correct_receiving_urls(self):
+        self.client.receiving.list()
+        self.assert_url_method(self.client, 'GET', '/receivings')
+
+        self.client.receiving.create()
+        self.assert_url_method(self.client, 'POST', '/receivings')
+
+        self.client.receiving.get(id=12345)
+        self.assert_url_method(self.client, 'GET', '/receivings/12345')
+
+        self.client.receiving.modify(id=12345)
+        self.assert_url_method(self.client, 'PUT', '/receivings/12345')
+
+        self.client.receiving.cancel(id=12345)
+        self.assert_url_method(self.client, 'POST', '/receivings/12345/cancel')
+
+        self.client.receiving.cancel_labels(id=5)
+        self.assert_url_method(self.client, 'POST',
+                               '/receivings/5/labels/cancel')
+
+        self.client.receiving.holds(id=54321)
+        self.assert_url_method(self.client, 'GET', '/receivings/54321/holds')
+
+        self.client.receiving.instructions_recipients(id=54321)
+        self.assert_url_method(self.client, 'GET',
+                               '/receivings/54321/instructionsRecipients')
+
+        self.client.receiving.items(id=54321)
+        self.assert_url_method(self.client, 'GET', '/receivings/54321/items')
+
+        self.client.receiving.shipments(id=54321)
+        self.assert_url_method(self.client, 'GET',
+                               '/receivings/54321/shipments')
+
+        self.client.receiving.trackings(id=54321)
+        self.assert_url_method(self.client, 'GET',
+                               '/receivings/54321/trackings')
+
+    def test_call_generates_correct_webhooks_urls(self):
+        self.client.webhooks.list()
+        self.assert_url_method(self.client, 'GET', '/webhooks')
+
+        self.client.webhooks.create()
+        self.assert_url_method(self.client, 'POST', '/webhooks')
+
+        self.client.webhooks.get(id=12345)
+        self.assert_url_method(self.client, 'GET', '/webhooks/12345')
+
+        self.client.webhooks.modify(id=12345)
+        self.assert_url_method(self.client, 'PUT', '/webhooks/12345')
+
+        self.client.webhooks.delete(id=12345)
+        self.assert_url_method(self.client, 'DELETE', '/webhooks/12345')
+
+    def test_call_requires_id_on_instance_operations(self):
+        with self.assertRaises(api.ShipwireError):
+            self.client.order.get(json={})
+
+    def test_call_requests_with_auth(self):
+        self.client.order.get(id=12345)
+        auth = api.requests.request.call_args[1]['auth']
+        self.assertEqual(self.client.auth, auth)
+
+    def test_call_respects_secure(self):
+        self.client.secure = True
+        self.client.order.get(id=12345)
+        uri = api.requests.request.call_args[0][1]
+        self.assertTrue(uri.startswith('https://'))
+
+    def test_call_respects_insecure(self):
+        self.client.secure = False
+        self.client.order.get(id=12345)
+        uri = api.requests.request.call_args[0][1]
+        self.assertTrue(uri.startswith('http://'))
+
+    def test_call_returns_correct_order_class(self):
+        self.assertIsInstance(self.client.order.list(),
+                              responses.ListResponse)
+
+        self.assertIsInstance(self.client.orders.list(),
+                              responses.ListResponse)
+
+        self.assertIsInstance(self.client.order.get(id=1234),
+                              responses.ShipwireResponse)
+
+        self.assertIsInstance(self.client.order.modify(id=1234),
+                              responses.ShipwireResponse)
+
+        self.assertIsInstance(self.client.order.holds(id=1234),
+                              responses.ListResponse)
+
+        self.assertIsInstance(self.client.order.items(id=1234),
+                              responses.ListResponse)
+
+        self.assertIsInstance(self.client.order.returns(id=1234),
+                              responses.ListResponse)
+
+        self.assertIsInstance(self.client.order.trackings(id=1234),
+                              responses.ListResponse)
+
+    def test_call_returns_correct_stock_response(self):
+        self.assertIsInstance(self.client.stock.products(),
+                              responses.ListResponse)
+
+    def test_call_returns_correct_rate_response(self):
+        self.assertIsInstance(self.client.rate.quote(),
+                              responses.ShipwireResponse)
+
+    def test_call_returns_correct_receiving_response(self):
+        self.assertIsInstance(self.client.receiving.list(),
+                              responses.ListResponse)
+
+        self.assertIsInstance(self.client.receiving.create(),
+                              responses.ShipwireResponse)
+
+        self.assertIsInstance(self.client.receiving.get(id=1234),
+                              responses.ShipwireResponse)
+
+        self.assertIsInstance(self.client.receiving.modify(id=1234),
+                              responses.ShipwireResponse)
+
+        self.assertIsInstance(self.client.receiving.cancel(id=1234),
+                              responses.ShipwireResponse)
+
+        self.assertIsInstance(self.client.receiving.cancel_labels(id=1234),
+                              responses.ShipwireResponse)
+
+        self.assertIsInstance(self.client.receiving.holds(id=1234),
+                              responses.ShipwireResponse)
+
+        self.assertIsInstance(
+            self.client.receiving.instructions_recipients(id=1234),
+            responses.ShipwireResponse)
+
+        self.assertIsInstance(self.client.receiving.items(id=1234),
+                              responses.ShipwireResponse)
+
+        self.assertIsInstance(self.client.receiving.shipments(id=1234),
+                              responses.ShipwireResponse)
+
+        self.assertIsInstance(self.client.receiving.trackings(id=1234),
+                              responses.ShipwireResponse)
+
+    def test_call_returns_correct_webhooks_response(self):
+        self.assertIsInstance(self.client.webhooks.list(),
+                              responses.ListResponse)
+
+        self.assertIsInstance(self.client.webhooks.create(),
+                              responses.ShipwireResponse)
+
+        self.assertIsInstance(self.client.webhooks.get(id=1234),
+                              responses.ShipwireResponse)
+
+        self.assertIsInstance(self.client.webhooks.modify(id=1234),
+                              responses.ShipwireResponse)
+
+        self.assertIsInstance(self.client.webhooks.delete(id=1234),
+                              responses.ShipwireResponse)

--- a/shipwire/tests/test_responses.py
+++ b/shipwire/tests/test_responses.py
@@ -1,0 +1,68 @@
+from unittest import TestCase
+
+from shipwire import responses
+
+try:
+    from unittest.mock import MagicMock, patch
+except ImportError:
+    from mock import MagicMock, patch
+
+
+def fake_response(payload):
+    json_fn = MagicMock(return_value=dict(payload))
+    return MagicMock(json=json_fn)
+
+
+def fake_list_response(items, next=None):
+    return fake_response({
+        'status': 200, 'resource': {'items': items, 'next': next}})
+
+
+class ShipwireResponseTestCase(TestCase):
+    def test_provides_resource(self):
+        resource = dict(id=123456)
+        response = fake_response({'resource': resource})
+        obj = responses.ShipwireResponse(response, MagicMock())
+
+        self.assertEqual(resource, obj.resource)
+
+
+class ListResponseTestCase(TestCase):
+    def test_provides_items(self):
+        item = dict(resource=dict(id=123456))
+        items = dict(items=[item])
+        response = fake_response({'status': 200, 'resource': items})
+        obj = responses.ListResponse(response, MagicMock())
+
+        self.assertEqual([item], obj.items)
+
+    def test_provides_next(self):
+        item = dict(resource=dict(id=123456))
+        items = dict(next=1234567, items=[item])
+        response = fake_response({'status': 200, 'resource': items})
+        obj = responses.ListResponse(response, MagicMock())
+
+        self.assertEqual(items['next'], obj.next)
+
+    @patch('shipwire.responses.requests.request')
+    def test_all_calls_until_end(self, mock):
+        initial_response = fake_list_response([], next=10)
+        subsequent = [20, 30, 40, None]
+
+        mock.side_effect = [fake_list_response([], next=p) for p in subsequent]
+
+        sw_response = responses.ListResponse(initial_response, MagicMock())
+        sw_response.all_serial()
+
+        self.assertEqual(len(subsequent), mock.call_count)
+
+    @patch('shipwire.responses.requests.request')
+    def test_all_returns_all_items(self, mock):
+        initial_response = fake_list_response([0], next=10)
+        subsequent = [20, 30, 40, None]
+
+        mock.side_effect = [fake_list_response([i + 1], next=p)
+                            for i, p in enumerate(subsequent)]
+
+        sw_response = responses.ListResponse(initial_response, MagicMock())
+        self.assertEqual([0, 1, 2, 3, 4], sw_response.all_serial())


### PR DESCRIPTION
Adds some basic unit tests to the project, as well as configuring [Travis-CI](https://travis-ci.org/) + [coveralls](https://coveralls.io/).  Travis was chosen over Codeship so that multiple Python versions could be tested somewhat easily.

The tests here aren't particularly exhaustive.  They're intended to prevent breaking API compatibility moving forward.
