### PR TITLE
Error handling and timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,31 @@ client.order.get(id="nonexistent")
 By default, this behavior is disabled to be backwards-compatible with
 previous versions of the library.
 
+##### Request timeouts:
+
+By default, this library does not enforce a time limit on requests.  A
+timeout may be configured by passing a `timeout` argument to the client.
+`timeout` may contain ([as with the underlying `requests` library][requests-timeouts])
+either a single float or a tuple in the format
+`(connect_timeout, read_timeout)`. If a timeout occurs (either a read or
+connect timeout), a `shipwire.TimeoutError` will be raised. Example:
+
+```python
+from shipwire import Shipwire, TimeoutError.
+
+client = Shipwire(username="...", password="...", timeout=(1.0, 10.0))
+
+try:
+    client.orders.get(id=order_id)
+except shipwire.TimeoutError:
+    # retry later
+```
+
+By default, this behavior is disabled to be backwards-compatible with
+previous versions of the library.
+
+[requests-timeouts]: http://docs.python-requests.org/en/master/user/advanced/#timeouts
+
 #####Methods that require information passed in json:
 You must supply information in json form for the rate.quote, order.create, and order.modify methods. Examples of the json data to be supplied can be found on the shipwire developer website at https://www.shipwire.com/w/developers/ or also in the text below.
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,26 @@ response.limit # returns a count of the current group
 response.all() # returns a list of all the items in the entire selection. Please note that this method can be time consuming and lead to timeout errors by the Shipwire API.
 ```
 
+##### Unsuccessful requests:
+
+Should Shipwire return a response indicating a failure (defined as
+having a status code greater than or equal to 400), a
+`shipwire.ResponseError` will be raised if desired.  You can
+control this behavior by passing `raise_on_errors=True` when creating
+your client:
+
+```python
+from shipwire import Shipwire
+
+client = Shipwire(username="...", password="...", raise_on_errors=True)
+
+client.order.get(id="nonexistent")
+# raises shipire.ResponseError
+```
+
+By default, this behavior is disabled to be backwards-compatible with
+previous versions of the library.
+
 #####Methods that require information passed in json:
 You must supply information in json form for the rate.quote, order.create, and order.modify methods. Examples of the json data to be supplied can be found on the shipwire developer website at https://www.shipwire.com/w/developers/ or also in the text below.
 

--- a/shipwire/exceptions.py
+++ b/shipwire/exceptions.py
@@ -1,0 +1,23 @@
+class ShipwireError(Exception):
+    """
+    Base Exception thrown by the Shipwire object when there is a
+    general error interacting with the API.
+    """
+    pass
+
+
+class ResponseError(ShipwireError):
+    """
+    Exception raised when a response indicating failure is encountered
+    """
+
+    def __init__(self, response):
+        try:
+            message = response.json()['message']
+        except:
+            message = "Unknown message"
+
+        super(ResponseError, self).__init__(
+            'Unexpected Status Code (%d): %s' %
+            (response.status_code, message))
+        self.response = response

--- a/shipwire/exceptions.py
+++ b/shipwire/exceptions.py
@@ -21,3 +21,10 @@ class ResponseError(ShipwireError):
             'Unexpected Status Code (%d): %s' %
             (response.status_code, message))
         self.response = response
+
+
+class TimeoutError(ShipwireError):
+    """
+    Exception raised when a timeout occurs.
+    """
+    pass

--- a/shipwire/tests/test_api.py
+++ b/shipwire/tests/test_api.py
@@ -3,14 +3,34 @@ from unittest import TestCase
 from shipwire import api, responses
 
 try:
-    from unittest.mock import MagicMock, patch
+    from unittest.mock import patch
 except ImportError:
-    from mock import MagicMock, patch
+    from mock import patch
 
 
-@patch('shipwire.requests.request', new=MagicMock())
+class StubResponse(object):
+    "A canned response with a similar API to requests.Response"
+
+    def __init__(self, status, json):
+        self.status_code = status
+        self._json = json
+
+    def json(self):
+        return self._json
+
+    @property
+    def content(self):
+        return str(self.json())
+
+
 class ShipwireTestCase(TestCase):
     def setUp(self):
+        patcher = patch('shipwire.requests.request')
+        self.addCleanup(patcher.stop)
+        self.request = patcher.start()
+
+        self.request.return_value = StubResponse(200, {})
+
         self.client = api.Shipwire()
 
     def assert_url(self, client, url):
@@ -168,6 +188,26 @@ class ShipwireTestCase(TestCase):
         self.client.order.get(id=12345)
         uri = api.requests.request.call_args[0][1]
         self.assertTrue(uri.startswith('http://'))
+
+    def test_call_raises_on_400_status_when_indicated(self):
+        self.client.raise_on_errors = True
+        self.request.return_value = StubResponse(403, {})
+
+        with self.assertRaises(api.ResponseError):
+            self.client.order.get(id=12345)
+
+    def test_call_raises_on_500_status_when_indicated(self):
+        self.client.raise_on_errors = True
+        self.request.return_value = StubResponse(500, {})
+
+        with self.assertRaises(api.ResponseError):
+            self.client.order.get(id=12345)
+
+    def test_call_doesnt_raise_when_indicated(self):
+        self.client.raise_on_errors = False
+        self.request.return_value = StubResponse(500, {})
+
+        self.client.order.get(id=12345)
 
     def test_call_returns_correct_order_class(self):
         self.assertIsInstance(self.client.order.list(),


### PR DESCRIPTION
This PR adds a few backwards-compatible changes for handling error conditions.

An option (`raise_on_errors`) is introduced which allows users to handle error-responses a little more explicitly:

``` python
client = Shipwire(username="...", password="...", raise_on_errors=True)

try:
    response = client.some.operation(json=malformed_data)
except shipwire.RequestError as exc:
    return handle_error(exc.response)

return handle_success(response)
```

As this behavior is backwards-incompatible, the user must opt in.  Existing code will be unaffected.

Another option (`timeout`) is introduced which allows users to specify timeout errors.  In practice, I've actually seen quite a few hung connections when interacting with Shipwire's API.  `requests` actually offers the ability to enforce timeouts, but there's currently no way to configure that outside of the package.  `timeout` allows a user to set time limits and handle them gracefully:

``` python
#1 second connect timeout, 10 second read timeout.
client = Shipwire(username="...", password="...", timeout=(1.0, 10.0))

try:
    response = client.some.long.operation()
except shipwire.TimeoutError as exc:
    return retry_later()
```

Both `RequestError` and `TimeoutError` descend from `ShipwireError`, meaning that a user is able to add a catch-all handler for all wrapper level errors (`except shipwire.ShipwireError:`).
