### PR TITLE
Add new endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,11 @@ This shipwire package currently provides the following methods for Shipwire API 
 ```python
 s.order.get(id=41949255) # returns an order resource for the given id.
 s.order.holds(id=41949255) # returns a list of holds on a given order.
+s.order.clear_holds(id=41949255) # clears holds on a given order.
 s.order.items(id=41949255) # returns a list of items in a given order.
 s.order.returns(id=41949255) # returns a list of returns for a given order.
 s.order.trackings(id=41949255) # returns a list of tracking information for a given order.
+s.order.split_orders(id=41949255) # returns a list of split orders for a given order.
 s.orders.list(updatedAfter="2014-10-19T21:09:26.030625") # returns a list of orders filtered by the parameters based to the method.
 s.stock.products() # returns a list of products that are listed in your shipwire account.
 s.rate.quote(json={}) # returns rate quotes based on the json information you supply. See a sample of the json below.
@@ -65,6 +67,15 @@ s.receiving.instructions_recipients(id=1234) # Get email recipients and instruct
 s.receiving.items(id=1234) # Get the contents of this receiving
 s.receiving.shipments(id=1234) # Get shipping dimension and container information
 s.receiving.trackings(id=1234) # Get tracking information about this receiving.
+s.receiving.labels(id=1234) # Get labels about a given receiving.
+s.returns.list() # Get a list of returns.
+s.returns.create(json=your_json) # create a new return or multiple returns.
+s.returns.get(id=1234) # returns a return resource for the given id.
+s.returns.cancel(id=1234) # cancel a return.
+s.returns.holds(id=1234) # returns a list of holds for a given return.
+s.returns.items(id=1234) # returns a list of items associated with a return.
+s.returns.trackings(id=1234) # returns tracking information associated with a given return.
+s.returns.labels(id=1234) # returns shipping labels associated with a given return.
 s.webhooks.list() # Get an itemized list of webhook subscriptions
 s.webhooks.create(json={'topic':'v1.order_updated', 'url':'https://requestbin.herokuapp.com/unique_id'}) # Create a new webhook subscription
 s.webhooks.get(id=1234) # Get information about a specific webhook

--- a/shipwire/api.py
+++ b/shipwire/api.py
@@ -13,10 +13,12 @@ METHODS = {
         'modify': ['PUT', 'orders', ''],
         'cancel': ['POST', 'orders', '/cancel'],
         'holds': ['GET', 'orders', '/holds'],
+        'clear_holds': ['POST', 'orders', '/holds/clear'],
         'items': ['GET', 'orders', '/items'],
         'returns': ['GET', 'orders', '/returns'],
         'trackings': ['GET', 'orders', '/trackings'],
         'list': ['GET', 'orders'],
+        'split_orders': ['GET', 'orders', '/splitOrders'],
     },
     'orders': {
         'list': ['GET', 'orders']
@@ -40,6 +42,17 @@ METHODS = {
         'items': ['GET', 'receivings', '/items'],
         'shipments': ['GET', 'receivings', '/shipments'],
         'trackings': ['GET', 'receivings', '/trackings'],
+        'labels': ['GET', 'receivings', '/labels'],
+    },
+    'returns': {
+        'list': ['GET', 'returns'],
+        'create': ['POST', 'returns'],
+        'get': ['GET', 'returns', ''],
+        'cancel': ['POST', 'returns', '/cancel'],
+        'holds': ['GET', 'returns', '/holds'],
+        'items': ['GET', 'returns', '/items'],
+        'trackings': ['GET', 'returns', '/trackings'],
+        'labels': ['GET', 'returns', '/labels'],
     },
     'webhooks': {
         'list': ['GET', 'webhooks'],

--- a/shipwire/responses.py
+++ b/shipwire/responses.py
@@ -1,9 +1,14 @@
+"""
+The following class names are paired with the methods listed
+at the top of the api module. If you add a method to the api
+module you must also add a corresponding Response class below.
+"""
+
 import requests
-#import grequests #hold until grequests package update
-#import copy
 
 HTTP_SUCCESS = 200
 SHIPWIRE_GET_ALL_LIMIT = 200
+
 
 class ShipwireResponse(object):
     def __init__(self, response, shipwire_instance):
@@ -20,22 +25,17 @@ class ShipwireResponse(object):
         self.errors = j.get('errors')
         self.shipwire = shipwire_instance
 
-"""
-The following class names are paired with the methods listed
-at the top of the api module. If you add a method to the api
-module you must also add a corresponding Response class below.
-"""
 
 class ListResponse(ShipwireResponse):
     def __init__(self, response, shipwire_instance):
         super(ListResponse, self).__init__(response, shipwire_instance)
 
-        #check to make sure that you have a valid response
+        # check to make sure that you have a valid response
         if self.status is not HTTP_SUCCESS:
             return
 
         r = self.resource
-        self.total =  r.get('total')
+        self.total = r.get('total')
         self.previous = r.get('previous')
         self.next = r.get('next')
         self.__next__ = r.get('next')
@@ -43,7 +43,6 @@ class ListResponse(ShipwireResponse):
         self.items = r.get('items')
         self.limit = len(self.items)
         self.all_serial = self._get_all_serial
-        #self.all_concurrent = self._get_all_conncurrent
         self.all = self.all_serial
 
     def _get_all_serial(self):
@@ -60,72 +59,70 @@ class ListResponse(ShipwireResponse):
 
         return items
 
-    """ hold for grequests package update with exception handling
-    def _get_all_conncurrent(self, size=4):
-        params_dicts = []
-        offset = 0
-        while offset < self.total:
-            params = copy.copy(self.shipwire.call_params)
-            params['offset'] = offset
-            if 'limit' not in params: #also append the limit
-                params['limit'] = SHIPWIRE_GET_ALL_LIMIT
-            params_dicts.append(params)
-            offset += params.get('limit', SHIPWIRE_GET_ALL_LIMIT)
-
-        print self.shipwire.uri
-        # stream=False, verify=True
-        rs = (grequests.get(self.shipwire.uri,auth=self.shipwire.auth,params=ps,timeout=90) for ps in params_dicts)
-        responses = grequests.map(rs,stream=True,size=size)
-
-        items = []
-        for response in responses:
-            list_resp = ListResponse(response,self.shipwire)
-            items.extend(list_resp.items)
-        return items
-
-    def _grequests_exception_handler(request, exception):
-        print 'request failed, lets try again.'
-    """
 
 class CreateResponse(ListResponse):
     pass
 
+
 class GetResponse(ShipwireResponse):
     pass
+
 
 class ModifyResponse(ShipwireResponse):
     pass
 
+
 class DeleteResponse(ShipwireResponse):
     pass
+
 
 class CancelResponse(ShipwireResponse):
     pass
 
+
 class ShipmentsResponse(ListResponse):
     pass
+
 
 class Instructions_recipientsResponse(ListResponse):
     pass
 
+
 class Cancel_labelsResponse(ListResponse):
     pass
+
 
 class HoldsResponse(ListResponse):
     pass
 
+
+class LabelsResponse(ListResponse):
+    pass
+
+
+class Clear_holdsResponse(ShipwireResponse):
+    pass
+
+
 class ItemsResponse(ListResponse):
     pass
+
 
 class ReturnsResponse(ListResponse):
     pass
 
+
 class TrackingsResponse(ListResponse):
     pass
+
 
 class ProductsResponse(ListResponse):
     pass
 
+
 class QuoteResponse(ShipwireResponse):
     pass
 
+
+class Split_ordersResponse(ListResponse):
+    pass

--- a/shipwire/tests/test_api.py
+++ b/shipwire/tests/test_api.py
@@ -102,11 +102,17 @@ class ShipwireTestCase(TestCase):
         self.client.order.holds(id=12345)
         self.assert_url_method(self.client, 'GET', '/orders/12345/holds')
 
+        self.client.order.clear_holds(id=12345)
+        self.assert_url_method(self.client, 'POST', '/orders/12345/holds/clear')
+
         self.client.order.returns(id=12345)
         self.assert_url_method(self.client, 'GET', '/orders/12345/returns')
 
         self.client.order.trackings(id=12345)
         self.assert_url_method(self.client, 'GET', '/orders/12345/trackings')
+
+        self.client.order.split_orders(id=12345)
+        self.assert_url_method(self.client, 'GET', '/orders/12345/splitOrders')
 
     def test_call_generates_correct_stock_urls(self):
         self.client.stock.products()
@@ -153,6 +159,35 @@ class ShipwireTestCase(TestCase):
         self.client.receiving.trackings(id=54321)
         self.assert_url_method(self.client, 'GET',
                                '/receivings/54321/trackings')
+
+        self.client.receiving.labels(id=5)
+        self.assert_url_method(self.client, 'GET',
+                               '/receivings/5/labels')
+
+    def test_call_generates_correct_returns_urls(self):
+        self.client.returns.list()
+        self.assert_url_method(self.client, 'GET', '/returns')
+
+        self.client.returns.create()
+        self.assert_url_method(self.client, 'POST', '/returns')
+
+        self.client.returns.get(id=12345)
+        self.assert_url_method(self.client, 'GET', '/returns/12345')
+
+        self.client.returns.cancel(id=12345)
+        self.assert_url_method(self.client, 'POST', '/returns/12345/cancel')
+
+        self.client.returns.holds(id=12345)
+        self.assert_url_method(self.client, 'GET', '/returns/12345/holds')
+
+        self.client.returns.items(id=12345)
+        self.assert_url_method(self.client, 'GET', '/returns/12345/items')
+
+        self.client.returns.trackings(id=12345)
+        self.assert_url_method(self.client, 'GET', '/returns/12345/trackings')
+
+        self.client.returns.labels(id=12345)
+        self.assert_url_method(self.client, 'GET', '/returns/12345/labels')
 
     def test_call_generates_correct_webhooks_urls(self):
         self.client.webhooks.list()
@@ -254,10 +289,16 @@ class ShipwireTestCase(TestCase):
         self.assertIsInstance(self.client.order.items(id=1234),
                               responses.ListResponse)
 
+        self.assertIsInstance(self.client.order.clear_holds(id=1234),
+                              responses.ShipwireResponse)
+
         self.assertIsInstance(self.client.order.returns(id=1234),
                               responses.ListResponse)
 
         self.assertIsInstance(self.client.order.trackings(id=1234),
+                              responses.ListResponse)
+
+        self.assertIsInstance(self.client.order.split_orders(id=1234),
                               responses.ListResponse)
 
     def test_call_returns_correct_stock_response(self):
@@ -302,6 +343,32 @@ class ShipwireTestCase(TestCase):
 
         self.assertIsInstance(self.client.receiving.trackings(id=1234),
                               responses.ShipwireResponse)
+
+        self.assertIsInstance(self.client.receiving.labels(id=1234),
+                              responses.ListResponse)
+
+    def test_call_returns_correct_returns_response(self):
+        self.assertIsInstance(self.client.returns.list(),
+                              responses.ListResponse)
+
+        self.assertIsInstance(self.client.returns.create(),
+                              responses.ShipwireResponse)
+
+        self.assertIsInstance(self.client.returns.get(id=1234),
+                              responses.ShipwireResponse)
+
+        self.assertIsInstance(self.client.returns.cancel(id=1234),
+                              responses.ShipwireResponse)
+
+        self.assertIsInstance(self.client.returns.holds(id=1234),
+                              responses.ListResponse)
+
+        self.assertIsInstance(self.client.returns.trackings(id=1234),
+                              responses.ListResponse)
+
+        self.assertIsInstance(self.client.returns.labels(id=1234),
+                              responses.ListResponse)
+
 
     def test_call_returns_correct_webhooks_response(self):
         self.assertIsInstance(self.client.webhooks.list(),


### PR DESCRIPTION
This PR adds a few new endpoints that seem to have cropped up in the last few months.  Notably, [`order.clear_holds`](https://www.shipwire.com/w/developers/orders/#panel-shipwire10) is now supported.

The wonky bit here is the introduction of the [`returns` resource](https://www.shipwire.com/w/developers/returns/).  Since `return` is a keyword in Python, we aren't able to expose `client.return.<action>` as is conventional for the library.  Here, I've chosen to use the plural (`client.returns.<action>`) to avoid the collision, however, [PEP8 addresses this issue explicity](http://legacy.python.org/dev/peps/pep-0008/#function-and-method-arguments):

> If your public attribute name collides with a reserved keyword, append a single trailing underscore to your attribute name. This is preferable to an abbreviation or corrupted spelling.

It's certainly debatable whether this should be `client.returns` or `client.return_`, however, a trailing underscore may confuse users who are new to Python or this library.  Perhaps something more verbose, such as `client.order_return`, might be better?
#### New endpoints:
- `order.clear_holds` - Clear all clear-able holds on a specific order.  The documentation suggests that this may only clear 'manual holds' (as specified in `options.hold` when creating) or system-generated holds.
- `order.split_orders` - List the split orders associated with a specific order.
- `receiving.labels` - List labels associated with a `receiving`.  Note that support for [`Accept: application/pdf`](https://www.shipwire.com/w/developers/receivings/#panel-shipwire11) is not implemented as it would require an overhaul of how responses are handled.
- `returns.list` - List returns
- `returns.create` - Create a return
- `returns.get` - Get a return
- `returns.cancel` - Cancel a return
- `returns.holds` - List holds associated with a return
- `returns.items` - List items associated with a return
- `returns.trackings` - List trackings associated with a return
- `returns.labels` - List labels associated with a return.
