### PR TITLE
Use generator for get_all_serial

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ response.next # returns a URL to the next group of items in the pagination
 response.offset # returns the nubmer of items offset by the current request
 response.items # returns a list of items in the current group
 response.limit # returns a count of the current group
-response.all() # returns a list of all the items in the entire selection. Please note that this method can be time consuming and lead to timeout errors by the Shipwire API.
+response.all() # returns a generator of all the items in the entire selection. Please note that this method can be time consuming and lead to timeout errors by the Shipwire API.
 ```
 
 ##### Unsuccessful requests:

--- a/shipwire/responses.py
+++ b/shipwire/responses.py
@@ -49,15 +49,15 @@ class ListResponse(ShipwireResponse):
         # loop over all items with previous and next
         next_uri = self.__next__
         req = self.response.request
-        items = self.items
+
+        for item in self.items:
+            yield item
 
         while next_uri:
             resp = requests.request(req.method, next_uri, auth=self.shipwire.auth)
             list_resp = ListResponse(resp, self.shipwire)
-            items.extend(list_resp.items)
+            yield from list_resp.items
             next_uri = list_resp.__next__
-
-        return items
 
 
 class CreateResponse(ListResponse):

--- a/shipwire/responses.py
+++ b/shipwire/responses.py
@@ -56,7 +56,8 @@ class ListResponse(ShipwireResponse):
         while next_uri:
             resp = requests.request(req.method, next_uri, auth=self.shipwire.auth)
             list_resp = ListResponse(resp, self.shipwire)
-            yield from list_resp.items
+            for item in list_resp.items:
+                yield item
             next_uri = list_resp.__next__
 
 

--- a/shipwire/tests/test_responses.py
+++ b/shipwire/tests/test_responses.py
@@ -52,7 +52,7 @@ class ListResponseTestCase(TestCase):
         mock.side_effect = [fake_list_response([], next=p) for p in subsequent]
 
         sw_response = responses.ListResponse(initial_response, MagicMock())
-        sw_response.all_serial()
+        list(sw_response.all_serial())
 
         self.assertEqual(len(subsequent), mock.call_count)
 
@@ -65,4 +65,4 @@ class ListResponseTestCase(TestCase):
                             for i, p in enumerate(subsequent)]
 
         sw_response = responses.ListResponse(initial_response, MagicMock())
-        self.assertEqual([0, 1, 2, 3, 4], sw_response.all_serial())
+        self.assertEqual([0, 1, 2, 3, 4], list(sw_response.all_serial()))


### PR DESCRIPTION
`get_all_serial` is used to iterate through a paginated response from
shipwire's API. Previously it would add each batch of items to a list
and then return that list once there were no more results to get.

This changes get_all_serial to be a generator, so that the program only
has to keep a single batch's worth of items in memory at a time. This is
especially helpful for grabbing large datasets from shipwire, because
you can begin processing resource items from shipwire while there are still items
to be fetched.