### PR TITLE
[WIP] Python 3.7 compatibilities + Add some new endpoints

### DIFF
--- a/shipwire/api.py
+++ b/shipwire/api.py
@@ -24,7 +24,7 @@ METHODS = {
         'list': ['GET', 'orders']
     },
     'stock': {
-        'products': ['GET', 'stock']
+        'list': ['GET', 'stock']
     },
     'rate': {
         'quote': ['POST', 'rate']
@@ -134,9 +134,14 @@ class Shipwire():
         http_method = endpoint[0]
 
         try:
-            res = requests.request(http_method, uri, auth=self.auth,
-                                   params=self.call_params,
-                                   timeout=self.timeout,)
+            if self.json:
+                res = requests.request(http_method, uri, auth=self.auth,
+                                       params=self.call_params, json=self.json,
+                                       timeout=self.timeout,)
+            else:
+                res = requests.request(http_method, uri, auth=self.auth,
+                                       params=self.call_params,
+                                       timeout=self.timeout,)
         except requests.exceptions.Timeout as exc:
             raise TimeoutError(exc)
 

--- a/shipwire/api.py
+++ b/shipwire/api.py
@@ -66,6 +66,18 @@ METHODS = {
         'create': ['POST', 'secret'],
         'get': ['GET', 'secret', ''],
         'delete': ['DELETE', 'secret', '']
+    },
+    'warehouses': {
+        'list': ['GET', 'warehouses'],
+        'create': ['POST', 'warehouses'],
+        'get': ['GET', 'warehouses', ''],
+        'delete': ['DELETE', 'warehouses', '']
+    },
+    'products': {
+        'list': ['GET', 'products'],
+        'create': ['POST', 'products'],
+        'get': ['GET', 'products', ''],
+        'delete': ['DELETE', 'products', '']
     }
 }
 
@@ -124,7 +136,7 @@ class Shipwire():
         try:
             res = requests.request(http_method, uri, auth=self.auth,
                                    params=self.call_params,
-                                   json=self.json, timeout=self.timeout)
+                                   timeout=self.timeout,)
         except requests.exceptions.Timeout as exc:
             raise TimeoutError(exc)
 


### PR DESCRIPTION
I noticed that there are few endpoints that works only on specific version:
Warehouse one work for API version 3.1, but there are another that does not work on 3.1 they do on 3.0
I'm not sure if I should handle this API version on METHOD definition.
